### PR TITLE
Optional bloom

### DIFF
--- a/crt.h
+++ b/crt.h
@@ -28,6 +28,9 @@ extern "C" {
  * Which, divided by 4, gives us 3.579545 MHz for the chroma carrier
  */
 
+/* do bloom emulation (side effect: makes screen have black borders) */
+#define CRT_DO_BLOOM    0
+
 #define CRT_CB_FREQ     4 /* carrier frequency relative to sample rate */
 #define CRT_HRES        (2275 * CRT_CB_FREQ / 10) /* horizontal resolution */
 #define CRT_VRES        262                       /* vertical resolution */


### PR DESCRIPTION
I was integrating this into my game and realized the bounding boxes of the UI buttons don't line up since the blooming requires the image be smaller than the frame. So I figured since others might want to add this to a modern game that uses mouse input, it would be good to have the option to not do blooming.