### PR TITLE
Optional sync

### DIFF
--- a/crt.c
+++ b/crt.c
@@ -538,7 +538,11 @@ crt_draw(struct CRT *v, int noise)
         }
     }
 vsync_found:
+#if CRT_DO_VSYNC
     v->vsync = line; /* vsync found (or gave up) at this line */
+#else
+    v->vsync = 0;
+#endif
     /* if vsync signal was in second half of line, odd field */
     field = (j > (CRT_HRES / 2));
 #if CRT_DO_BLOOM
@@ -581,7 +585,11 @@ vsync_found:
                 break;
             }
         }
+#if CRT_DO_HSYNC
         v->hsync = POSMOD(i + v->hsync, CRT_HRES);
+#else
+        v->hsync = 0;
+#endif
        
         sig = v->inp + ln + (v->hsync & ~3); /* burst @ 1/CB_FREQ sample rate */
         for (i = CB_BEG; i < CB_BEG + (CB_CYCLES * CRT_CB_FREQ); i++) {

--- a/crt.h
+++ b/crt.h
@@ -29,7 +29,9 @@ extern "C" {
  */
 
 /* do bloom emulation (side effect: makes screen have black borders) */
-#define CRT_DO_BLOOM    0
+#define CRT_DO_BLOOM    1
+#define CRT_DO_VSYNC    1  /* look for VSYNC */
+#define CRT_DO_HSYNC    1  /* look for HSYNC */
 
 #define CRT_CB_FREQ     4 /* carrier frequency relative to sample rate */
 #define CRT_HRES        (2275 * CRT_CB_FREQ / 10) /* horizontal resolution */


### PR DESCRIPTION
Can change #defines at the top of crt.h to toggle sync detection. Can help if vsync instability gets annoying at higher noise levels, for example.