### PR TITLE
Add CMake with PL3D-KC auto-install if requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.14...3.25)
+
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT is_multi_config AND NOT (CMAKE_BUILD_TYPE OR DEFINED ENV{CMAKE_BUILD_TYPE}))
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Release default")
+endif()
+
+project(NTSC-CRT LANGUAGES C)
+
+option(live "live video using PL3D-KC")
+
+include(ExternalProject)
+include(GNUInstallDirs)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}" CACHE PATH "default install path" FORCE)
+endif()
+
+# --- PL3D-KC
+if(live)
+if(UNIX)
+  find_package(X11 REQUIRED)
+endif()
+
+set(fw_url https://github.com/LMP88959/PL3D-KC.git)
+set(fw_tag 3fa35ad)
+set(fw_args
+-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+-DCMAKE_BUILD_TYPE=Release
+-DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+)
+
+set(FW_LIBRARY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}fw${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(FW_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+
+
+ExternalProject_Add(fw
+GIT_REPOSITORY ${fw_url}
+GIT_TAG ${fw_tag}
+GIT_SHALLOW true
+CMAKE_ARGS ${fw_args}
+BUILD_BYPRODUCTS ${FW_LIBRARY}
+TLS_VERIFY true
+INACTIVITY_TIMEOUT 60
+CONFIGURE_HANDLED_BY_BUILD ON
+)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
+add_library(fw::fw INTERFACE IMPORTED)
+target_link_libraries(fw::fw INTERFACE ${FW_LIBRARY}
+$<$<BOOL:${UNIX}>:X11::Xext>
+$<$<BOOL:${WIN32}>:winmm>
+)
+target_include_directories(fw::fw INTERFACE ${FW_INCLUDE_DIR})
+
+add_dependencies(fw::fw fw)
+endif()
+
+# --- NTSC program
+add_executable(ntsc crt.c ntsc_crt.c ppm_rw.c)
+target_include_directories(ntsc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(ntsc PRIVATE CMD_LINE_VERSION=$<NOT:$<BOOL:${live}>>)
+target_link_libraries(ntsc PRIVATE
+$<$<BOOL:${live}>:fw::fw>
+$<$<BOOL:${WIN32}>:winmm>
+)
+
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ to emulate NTSC output.
 ================================================================
 Feature List:
 
-- Somewhat realistic/accurate composite NTSC image output  
-  -- with bandlimited luma/chroma  
-  -- color artifacts (extends to being able to show specially patterned b/w images as color)  
+- Somewhat realistic/accurate composite NTSC image output
+  -- with bandlimited luma/chroma
+  -- color artifacts (extends to being able to show specially patterned b/w images as color)
 - VSYNC and HSYNC
 - Signal noise (optional)
 - Interlaced and progressive scan
 - Monochrome and full color
 - Vertically aligned chroma OR checkerboard chroma (specified in #define in header)
- 
+
 ## Important
 The command line program provided does not let you mess with all the settings
 like black/white point, brightness, saturation, and contrast.
@@ -47,12 +47,22 @@ The famous waterfall 'rainbow' effect created as a result of dithering will show
 Specially patterned black and white images can be encoded/decoded with color just like a real composite NTSC display.
 
 ## Compiling
-```
-  cd NTSC-CRT
-  
-  cc -O3 -o ntsc *.c
 
+```sh
+cd NTSC-CRT
+
+cc -O3 -o ntsc *.c
 ```
+
+or using CMake on Linux, macOS, or Windows:
+
+```sh
+cmake -B build
+cmake --build build
+build/ntsc
+```
+
+The default command line takes a single PPM image file and outputs a processed PPM file:
 
 ```
 usage: ./ntsc -m|o|f|p|r|h outwidth outheight noise phase_offset infile outfile
@@ -70,6 +80,15 @@ sample usage: ./ntsc - 832 624 0 2 in.ppm out.ppm
 
 by default, the image will be full color, interlaced, and scaled to the output dimensions
 ```
+
+There is also the option of "live" rendering to a video window from an input PPM image file:
+
+```sh
+cmake -B build -Dlive=on
+cmake --build build
+build/ntsc my.ppm
+```
+
 If you have any questions feel free to leave a comment on YouTube OR
 join the King's Crook Discord server :)
 

--- a/ntsc_crt.c
+++ b/ntsc_crt.c
@@ -377,7 +377,7 @@ displaycb(void)
 
     crt_draw(&crt, noise);
 
-    vid_swapbuffers();
+    vid_blit();
     vid_sync();
 }
 


### PR DESCRIPTION
* corrects vid_swapbuffers() to vid_blit() from PL3D-KC
* makes default value for console type if not defined in build (default not live-rendering as it was)
* for live=on, require user to specify input file on command line (this was hard-coded filename before)

The `cmake -Dlive=on` (default off) auto-downloads and build PL3D-KC. The live-rendering works on Linux, macOS and Windows.