### PR TITLE
re-arrange ppm_rw include to fix compiler error on size_t

### DIFF
--- a/ppm_rw.c
+++ b/ppm_rw.c
@@ -8,10 +8,11 @@
  *   Discord: https://discord.com/invite/hdYctSmyQJ
  */
 /*****************************************************************************/
-#include "ppm_rw.h"
 
 #include <stdlib.h>
 #include <stdio.h>
+
+#include "ppm_rw.h"
 
 extern int
 ppm_read24(char *file,


### PR DESCRIPTION
This fixes the following errors I received when attempting to compile on MacOS:

```
In file included from ppm_rw.c:11:
./ppm_rw.h:23:38: error: redefinition of parameter 'size_t'
        void *(*calloc_func)(size_t, size_t));
                                     ^
./ppm_rw.h:23:30: error: a parameter list without types is only allowed in a function definition
        void *(*calloc_func)(size_t, size_t));
                             ^
```