### PR TITLE
Moved random noise to CRT structure, initialize once in ::crtnes_init().

### DIFF
--- a/crt_nes.c
+++ b/crt_nes.c
@@ -209,6 +209,7 @@ crtnes_init(struct CRT *v, int w, int h, int *out)
     memset(v, 0, sizeof(struct CRT));
     crtnes_resize(v, w, h, out);
     crtnes_reset(v);
+    v->rn = 194;
             
     /* kilohertz to line sample conversion */
 #define kHz2L(kHz) (CRT_HRES * (kHz * 100) / L_FREQ)
@@ -437,9 +438,8 @@ crtnes_draw(struct CRT *v, int noise)
     ccref[2] = v->ccf[2] << 7;
     ccref[3] = v->ccf[3] << 7;
 
+    int rn = v->rn;
     for (i = 0; i < CRT_INPUT_SIZE; i++) {
-        static int rn = 194; /* 'random' noise */
-
         rn = (214019 * rn + 140327895);
 
         /* signal + noise */
@@ -448,6 +448,7 @@ crtnes_draw(struct CRT *v, int noise)
         if (s < -127) { s = -127; }
         v->inp[i] = s;
     }
+    v->rn = rn;
 
     /* Look for vertical sync.
      * 

--- a/crt_nes.h
+++ b/crt_nes.h
@@ -70,6 +70,7 @@ struct CRT {
     int black_point, white_point; /* user-adjustable */
     int outw, outh; /* output width/height */
     int *out; /* output image */
+    int rn; /* 'random' noise */
 };
 
 /* Initializes the library. Sets up filters.


### PR DESCRIPTION
Improves performance a bit.