### PR TITLE
Changes to values in pv10k header that match the timings of 4.47mhz

### DIFF
--- a/crt_pv1k.h
+++ b/crt_pv1k.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /* NOTE, in general, increasing CRT_CB_FREQ reduces blur and bleed */
 #define CRT_CB_FREQ     5 /* carrier frequency relative to sample rate */
-#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ / 10) /* horizontal res */
+#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ / 6) /* horizontal res */
 #define CRT_VRES        262                       /* vertical resolution */
 #define CRT_INPUT_SIZE  (CRT_HRES * CRT_VRES)
 
@@ -61,13 +61,15 @@ extern "C" {
  *      BLANK            SYNC           BLANK          BLANK          BLANK
  * 
  */
+#define DOT_ns 223
+#define DOTx4_ns 892
 #define LINE_BEG         0
-#define FP_ns            1500      /* front porch */
-#define SYNC_ns          4700      /* sync tip */
-#define BW_ns            600       /* breezeway */
-#define CB_ns            2500      /* color burst */
-#define BP_ns            1600      /* back porch */
-#define AV_ns            52600     /* active video */
+#define FP_ns            (2*DOTx4_ns)      /* front porch */
+#define SYNC_ns          (4*DOTx4_ns)      /* sync tip */
+#define BW_ns            (2*DOTx4_ns)       /* breezeway */
+#define CB_ns            (4*DOTx4_ns)      /* color burst */
+#define BP_ns            (4*DOTx4_ns)      /* back porch */
+#define AV_ns            (55*DOTx4_ns)     /* active video */
 #define HB_ns            (FP_ns + SYNC_ns + BW_ns + CB_ns + BP_ns) /* h blank */
 /* line duration should be ~63500 ns */
 #define LINE_ns          (FP_ns + SYNC_ns + BW_ns + CB_ns + BP_ns + AV_ns)

--- a/crt_pv1k.h
+++ b/crt_pv1k.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /* NOTE, in general, increasing CRT_CB_FREQ reduces blur and bleed */
 #define CRT_CB_FREQ     5 /* carrier frequency relative to sample rate */
-#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ /6) /* horizontal res */
+#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ / 6) /* horizontal res */
 #define CRT_VRES        262                       /* vertical resolution */
 #define CRT_INPUT_SIZE  (CRT_HRES * CRT_VRES)
 

--- a/crt_pv1k.h
+++ b/crt_pv1k.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /* NOTE, in general, increasing CRT_CB_FREQ reduces blur and bleed */
 #define CRT_CB_FREQ     5 /* carrier frequency relative to sample rate */
-#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ / 6) /* horizontal res */
+#define CRT_HRES        (CRT_CC_LINE * CRT_CB_FREQ /6) /* horizontal res */
 #define CRT_VRES        262                       /* vertical resolution */
 #define CRT_INPUT_SIZE  (CRT_HRES * CRT_VRES)
 
@@ -64,8 +64,8 @@ extern "C" {
 #define DOT_ns 223
 #define DOTx4_ns 892
 #define LINE_BEG         0
-#define FP_ns            (2*DOTx4_ns)      /* front porch */
-#define SYNC_ns          (4*DOTx4_ns)      /* sync tip */
+#define FP_ns            (3*DOTx4_ns)      /* front porch */
+#define SYNC_ns          (3*DOTx4_ns)      /* sync tip */
 #define BW_ns            (2*DOTx4_ns)       /* breezeway */
 #define CB_ns            (4*DOTx4_ns)      /* color burst */
 #define BP_ns            (4*DOTx4_ns)      /* back porch */


### PR DESCRIPTION
Changed the timings to more closely match that of the PV-1000 hardware with a dot clock of 4.47mhz.